### PR TITLE
Support install from ANTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Ansible Role: Homebrew
 
-[![Build Status][travis-badge]][travis-link]
 [![MIT licensed][mit-badge]][mit-link]
-[![Galaxy Role][role-badge]][galaxy-link]
 
 Installs [Homebrew][homebrew] on MacOS, and configures packages, taps, and cask apps according to supplied variables.
 
@@ -13,6 +11,10 @@ None.
 ## Role Variables
 
 Available variables are listed below, along with default values (see [`defaults/main.yml`](defaults/main.yml)):
+
+    homebrew_user_id:
+
+By default the role will attempt to look for the user id of user logged into the console. Optionally you can set this variable to be the local user you want to own the homebrew install. Parts of the install need root access and part need the local user.
 
     homebrew_repo: https://github.com/Homebrew/brew
 
@@ -69,10 +71,6 @@ Whether to install via a Brewfile. If so, you will need to install the `homebrew
 
 The directory where your Brewfile is located.
 
-## Dependencies
-
-  - [elliotweiser.osx-command-line-tools][dep-osx-clt-role]
-
 ## Example Playbook
 
     - hosts: localhost
@@ -92,23 +90,18 @@ Ansible's `local` connection. See also:
 
 ## Author Information
 
-This role was created in 2014 by [Jeff Geerling][author-website], author of
+This role was forked from the work created in 2014 by [Jeff Geerling][author-website], author of
 [Ansible for DevOps][ansible-for-devops].
 
 #### Maintainer(s)
 
-- [Jeff Geerling](https://github.com/geerlingguy)
-- [Elliot Weiser](https://github.com/elliotweiser)
+- [Scott Knight](https://github.com/knightsc)
 
 [ansible-for-devops]: https://www.ansiblefordevops.com/
 [author-website]: https://www.jeffgeerling.com/
 [caskroom]: https://caskroom.github.io/search
-[galaxy-link]: https://galaxy.ansible.com/geerlingguy/homebrew/
 [homebrew]: http://brew.sh/
 [mac-dev-playbook]: https://github.com/geerlingguy/mac-dev-playbook
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-link]: https://raw.githubusercontent.com/geerlingguy/ansible-role-homebrew/master/LICENSE
-[dep-osx-clt-role]: https://galaxy.ansible.com/elliotweiser/osx-command-line-tools/
-[role-badge]: https://img.shields.io/ansible/role/1858.svg
-[travis-badge]: https://travis-ci.org/geerlingguy/ansible-role-homebrew.svg?branch=master
-[travis-link]: https://travis-ci.org/geerlingguy/ansible-role-homebrew
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,28 +1,29 @@
 ---
+homebrew_user_id_full:
+  stdout: overridden
+homebrew_user_id: "{{ homebrew_user_id_full.stdout }}"
+
 homebrew_repo: https://github.com/Homebrew/brew
 
 homebrew_prefix: /usr/local
 homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
 homebrew_brew_bin_path: /usr/local/bin
 
-homebrew_installed_packages:
-  - ssh-copy-id
-  - pv
+homebrew_installed_packages: []
 
 homebrew_uninstalled_packages: []
 
-homebrew_upgrade_all_packages: no
+homebrew_upgrade_all_packages: false
 
 homebrew_taps:
   - homebrew/core
   - homebrew/cask
 
-homebrew_cask_apps:
-  - firefox
+homebrew_cask_apps: []
 
 homebrew_cask_uninstalled_apps: []
 
 homebrew_cask_appdir: /Applications
 
-homebrew_use_brewfile: true
+homebrew_use_brewfile: false
 homebrew_brewfile_dir: '~'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,13 +1,11 @@
 ---
-dependencies:
-  - elliotweiser.osx-command-line-tools
+dependencies: []
 
 galaxy_info:
-  author: geerlingguy
+  author: knightsc
   description: Homebrew for Mac OS X
-  company: "Midwestern Mac, LLC"
-  license: "license (BSD, MIT)"
-  min_ansible_version: 1.9
+  license: MIT
+  min_ansible_version: 2.1
   platforms:
     - name: MacOSX
       versions:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,0 @@
----
-- src: elliotweiser.osx-command-line-tools

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+# System prerequisites
+- name: Check that there is a logged in user
+  shell: "/bin/ls -l /dev/console | /usr/bin/awk '{ print $3 }'"
+  register: homebrew_user_id_full
+
+- name: Is a user logged in?
+  fail:
+    msg: There is no currently logged in user
+  when: homebrew_user_id == ''
+
+- name: Check that the Command Line Tools are present
+  stat:
+    path: /Library/Developer/CommandLineTools/usr/bin/git
+  register: clt
+
+- name: Are the Command Line Tools present?
+  fail:
+    msg: System is missing the Command Line Tools
+  when: not clt.stat.exists
+
 # Homebrew setup prerequisites.
 - name: Ensure Homebrew parent directory has correct permissions (on High Sierra).
   file:
@@ -21,7 +41,7 @@
 - name: Ensure Homebrew directory exists.
   file:
     path: "{{ homebrew_install_path }}"
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ homebrew_user_id }}"
     group: admin
     state: directory
     mode: 0775
@@ -36,13 +56,15 @@
     update: no
     accept_hostkey: yes
     depth: 1
+  become: yes
+  become_user: "{{ homebrew_user_id }}"
 
 # Adjust Homebrew permissions.
 - name: Ensure proper permissions and ownership on homebrew_brew_bin_path dirs.
   file:
     path: "{{ homebrew_brew_bin_path }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ homebrew_user_id }}"
     group: admin
     mode: 0775
   become: yes
@@ -51,7 +73,7 @@
   file:
     path: "{{ homebrew_install_path }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ homebrew_user_id }}"
     group: admin
   become: yes
 
@@ -72,7 +94,7 @@
   file:
     path: "{{ homebrew_prefix }}/{{ item }}"
     state: directory
-    owner: "{{ ansible_user_id }}"
+    owner: "{{ homebrew_user_id }}"
     group: admin
   become: yes
   with_items:
@@ -94,11 +116,15 @@
 - name: Force update brew after installation.
   command: "{{ homebrew_brew_bin_path }}/brew update --force"
   when: homebrew_binary.stat.exists == false
+  become: yes
+  become_user: "{{ homebrew_user_id }}"  
 
 # Tap.
 - name: Ensure configured taps are tapped.
   homebrew_tap: "tap={{ item }} state=present"
   with_items: "{{ homebrew_taps }}"
+  become: yes
+  become_user: "{{ homebrew_user_id }}"  
 
 # Cask.
 - name: Install configured cask applications.
@@ -107,10 +133,14 @@
     state: present
     install_options: "appdir={{ homebrew_cask_appdir }}"
   with_items: "{{ homebrew_cask_apps }}"
+  become: yes
+  become_user: "{{ homebrew_user_id }}"  
 
 - name: Ensure blacklisted cask applications are not installed.
   homebrew_cask: "name={{ item }} state=absent"
   with_items: "{{ homebrew_cask_uninstalled_apps }}"
+  become: yes
+  become_user: "{{ homebrew_user_id }}"
 
 # Brew.
 - name: Ensure configured homebrew packages are installed.
@@ -119,14 +149,20 @@
     install_options: "{{ item.install_options | default(omit) }}"
     state: present
   with_items: "{{ homebrew_installed_packages }}"
+  become: yes
+  become_user: "{{ homebrew_user_id }}"
 
 - name: Ensure blacklisted homebrew packages are not installed.
   homebrew: "name={{ item }} state=absent"
   with_items: "{{ homebrew_uninstalled_packages }}"
+  become: yes
+  become_user: "{{ homebrew_user_id }}"
 
 - name: Upgrade all homebrew packages (if configured).
   homebrew: update_homebrew=yes upgrade_all=yes
   when: homebrew_upgrade_all_packages
+  become: yes
+  become_user: "{{ homebrew_user_id }}"
 
 - name: Check for Brewfile.
   stat:
@@ -136,3 +172,5 @@
 - name: Install from Brewfile.
   command: "brew bundle chdir={{ homebrew_brewfile_dir }}"
   when: homebrew_brewfile.stat.exists and homebrew_use_brewfile
+  become: yes
+  become_user: "{{ homebrew_user_id }}"

--- a/tasks/playbook.yml
+++ b/tasks/playbook.yml
@@ -3,4 +3,4 @@
   connection: local
 
   roles:
-    - geerlingguy.homebrew
+    - knightsc.homebrew

--- a/tests/local-testing/playbook.yml
+++ b/tests/local-testing/playbook.yml
@@ -2,4 +2,4 @@
 - hosts: local
 
   roles:
-    - geerlingguy.homebrew
+    - knightsc.homebrew

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,4 @@
 - hosts: localhost
 
   roles:
-    - elliotweiser.osx-command-line-tools
     - ansible-role-homebrew


### PR DESCRIPTION
The [ANTS Framework](https://github.com/ANTS-Framework/ants) uses `ansible-pull` and runs as root on macOS machines to enable automatic configuration of them. Since playbooks are run as root and homebrew needs to be installed by a local user we have to make sure actions are taken as the appropriate user either root or the local user. This PR modifies the original role to automatically determine the user logged into the machine and run each task as the appropriate user. Additionally since ANTS makes sure command line tools are installed that original dependency is removed.